### PR TITLE
fix: clean up Discord RPC shutdown

### DIFF
--- a/electron/src/discordRpc.ts
+++ b/electron/src/discordRpc.ts
@@ -14,6 +14,12 @@ export interface DiscordRpcPayload {
 const DISCORD_CLIENT_ID = "1401296138186788865";
 const ROTATE_INTERVAL_MS = 10_000;
 const RPC_SHUTDOWN_WAIT_MS = 1_500;
+const RPC_BUTTONS = [
+    {
+        label: "Get it on GitHub",
+        url: "https://github.com/Rares-Muntean/TruckNav-Sim",
+    },
+];
 
 let rpcLib: any = null;
 let rpcClient: any = null;
@@ -139,7 +145,7 @@ export async function destroyDiscordRpc(useIdleFlush = true) {
     } catch {}
 
     try {
-        rpcClient.destroy();
+        await rpcClient.destroy();
     } catch {}
 
     rpcClient = null;
@@ -183,17 +189,16 @@ async function waitForDiscordRpcFlush(delayMs: number) {
 async function setIdlePresence() {
     if (!rpcClient || !rpcReady) return;
 
-    await rpcClient.setActivity({
+    const presence = {
         details: "TruckNav",
         state: "Waiting for telemetry",
         largeImageText: "TruckNav",
+        buttons: RPC_BUTTONS,
         instance: false,
-    });
+    };
 
-    lastPayloadKey = JSON.stringify({
-        details: "TruckNav",
-        state: "Waiting for telemetry",
-    });
+    await rpcClient.setActivity(presence);
+    lastPayloadKey = JSON.stringify(presence);
 }
 
 async function pushCurrentPresence() {
@@ -250,15 +255,10 @@ function buildPresence(payload: DiscordRpcPayload) {
         details,
         state,
         largeImageText: "TruckNav",
-        buttons: [
-            {
-                label: "Get it on GitHub",
-                url: "https://github.com/Rares-Muntean/TruckNav-Sim",
-            },
-        ],
+        buttons: RPC_BUTTONS,
         startTimestamp:
             payload.connected && sessionStartedAt > 0
-                ? Math.floor(sessionStartedAt / 1000)
+                ? sessionStartedAt
                 : undefined,
         instance: false,
     };


### PR DESCRIPTION
## Changes

- Waits for the Discord RPC client to disconnect before Electron exits
- Fixes the activity timestamp by passing the expected millisecond value
- Reuses the GitHub button configuration for both active telemetry and the idle presence
- Prevents the previous Rich Presence from remaining stuck after quitting TruckNav

## Testing

- Successfully ran the Electron build
- Tested quitting TruckNav through the tray menu
- Confirmed that the Rich Presence is cleared correctly after the application exits

## Note

Discord only shows custom Rich Presence buttons to other users, so the GitHub button must be verified from another Discord account.